### PR TITLE
Add a main so that we can 'go get' it as a CLI  ✨

### DIFF
--- a/cmd/namegenerator/main.go
+++ b/cmd/namegenerator/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/goombaio/namegenerator"
+)
+
+func main() {
+	seed := time.Now().UTC().UnixNano()
+	nameGenerator := namegenerator.NewNameGenerator(seed)
+
+	name := nameGenerator.Generate()
+
+	fmt.Println(name)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/goombaio/namegenerator
+
+go 1.15


### PR DESCRIPTION
**Goal**: make it possible to use this module as a CLI. This way, users can simply install the `namegenerator` CLI by running

```sh
go get github.com/goombaio/namegenerator/cmd/namegenerator
```

What do you think? 😊

Should I add a line to the README?